### PR TITLE
refactor(tools): Support for Capitalized Extensions

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -35,16 +35,12 @@ fn create_dirs(dir_names: HashSet<String>) {
 }
 
 fn get_folder_by_extension(file_path: &str) -> String {
-    let file_extension = file_path.split(".").last();
-    String::from(match file_extension {
-        Some("png") | Some("jpg") | Some("jpeg") | Some("webp") | Some("gif") | Some("svg") => {
-            "Images"
-        }
-        Some("mp4") | Some("avi") | Some("mov") => "Videos",
-        Some("pdf") | Some("doc") | Some("docx") | Some("txt") | Some("ppt") | Some("pptx") => {
-            "Documents"
-        }
-        _ => "",
+    let file_extension = file_path.split(".").last().unwrap_or("").to_lowercase();
+    String::from(match file_extension.as_str() {
+        "png" | "jpg" | "jpeg" | "webp" | "gif" | "svg" | "heic" => "Images",
+        "mp4" | "avi" | "mov" => "Videos",
+        "pdf" | "doc" | "docx" | "txt" | "ppt" | "pptx" | "csv" => "Documents",
+        _ => "Others",
     })
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,7 +40,7 @@ fn get_folder_by_extension(file_path: &str) -> String {
         "png" | "jpg" | "jpeg" | "webp" | "gif" | "svg" | "heic" => "Images",
         "mp4" | "avi" | "mov" => "Videos",
         "pdf" | "doc" | "docx" | "txt" | "ppt" | "pptx" | "csv" => "Documents",
-        _ => "Others",
+        _ => "",
     })
 }
 


### PR DESCRIPTION
👋  @doganalper, I just did a minor update on your code 

**Issue Description:**
Currently, the repository handles file extensions in lowercase (like.jpg, .mov). In many instances, files are saved with capitalized extensions (e.g., .JPG, .MOV), especially those from certain devices or software. The current implementation does not recognize or organize these capitalized extensions effectively.

**What:**
1. **Support for Capitalized Extensions:** It would be helpful to support the lowercase and uppercase file extensions. This way, files with extensions like .JPG or .MOV can also be organized correctly.

2. **New Extensions:** Additionally, I suggest adding support for the [.heic](https://en.wikipedia.org/wiki/High_Efficiency_Image_File_Format) and `.csv` file formats. 

~~3. **Others directory for rest**: I do not have a strong opinion for that but it is good to have it~~